### PR TITLE
Don't install the non-free Flash plugin anymore.

### DIFF
--- a/config/hooks/flash.chroot
+++ b/config/hooks/flash.chroot
@@ -1,2 +1,0 @@
-#!/bin/sh
-update-flashplugin-nonfree --install

--- a/config/package-lists/gui.list.chroot
+++ b/config/package-lists/gui.list.chroot
@@ -2,9 +2,6 @@
 # where "functional" means that you can use it to do simple tests
 gigolo
 
-# Flash (Shit!)
-flashplugin-nonfree
-
 # LibreOffice
 libreoffice-writer
 libreoffice-calc


### PR DESCRIPTION
Installing Flash may have made sense a few years ago, when it was often needed,
mainly for YouTube support. Back then, e.g. it was one of the top-requested
features by Tails users.

Nowadays, Flash is disappearing from the web, YouTube works fine without it most
of the time, and e.g. Tails users have basically stopped asking for Flash.

I suspect that this commit should be completed by more cleanup: I see
Flash-related things e.g.
in config/includes.chroot/etc/skel/.icedove/a0wcqjkh.default/pluginreg.dat.
But I won't fiddle with auto-generated files that IMO should not be stored in
Git to start with, so I'll let this one to someone else who's more comfortable
than me with the current Firefox profile implementation.
